### PR TITLE
Add spinner to translation loading overlay

### DIFF
--- a/mobile/app/(tabs)/index.tsx
+++ b/mobile/app/(tabs)/index.tsx
@@ -11,6 +11,7 @@ import {
   Pressable,
   Platform,
   Alert,
+  ActivityIndicator,
 } from 'react-native';
 import { Audio } from 'expo-av'; // Audio recording and playback library
 import { Ionicons } from '@expo/vector-icons'; // Icons for UI elements
@@ -680,7 +681,10 @@ export default function TranslateScreen() {
       {/* Loading overlay */}
       {isLoading && (
         <View style={styles.loadingContainer}>
-          <Text style={styles.loadingText}>Processing audio...</Text>
+          <View style={styles.loadingContent}>
+            <ActivityIndicator size="small" color="#fff" />
+            <Text style={styles.loadingText}>Processing audio...</Text>
+          </View>
         </View>
       )}
     </View>
@@ -808,6 +812,11 @@ const styles = StyleSheet.create({
     backgroundColor: 'rgba(0,0,0,0.7)',
     justifyContent: 'center',
     alignItems: 'center',
+  },
+  loadingContent: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 8,
   },
   loadingText: {
     color: '#fff',


### PR DESCRIPTION
## Summary
- import the React Native ActivityIndicator for the translate screen
- wrap the loading message with a horizontal layout and add the spinner next to the text
- style the overlay content to align the loading indicator and label with spacing

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_b_68e196c4f84c832a9dbf5bace98ef9f8