### PR TITLE
Add haptic feedback and auto-play for translations

### DIFF
--- a/mobile/app/(tabs)/index.tsx
+++ b/mobile/app/(tabs)/index.tsx
@@ -21,6 +21,7 @@ import { HistoryItem } from './history'; // Type definition for history items
 import { router, useFocusEffect } from 'expo-router'; // For navigation and focus events
 import * as FileSystem from 'expo-file-system/legacy'; // For file operations (using legacy API)
 import { VoiceProviderSettings } from '../components/VoiceProviderSelector'; // Voice provider settings
+import * as Haptics from 'expo-haptics';
 
 // API endpoint for audio processing and translation
 const API_URL = 'https://fond-workable-firefly.ngrok-free.app';
@@ -213,6 +214,7 @@ export default function TranslateScreen() {
    */
   const startRecording = async () => {
     try {
+      Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Medium);
       // Reset state for new recording
       setProcessingError(null);
       await cleanupResources();
@@ -283,6 +285,7 @@ export default function TranslateScreen() {
     }
 
     try {
+      Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
       setIsRecording(false);
       let uri: string | null = null;
 
@@ -414,6 +417,12 @@ export default function TranslateScreen() {
       setTranscribedText(transcribed_text);
       setTranslatedText(translated_text);
       setTranslatedAudio(fullAudioUrl);
+      setTimeout(() => {
+        if (fullAudioUrl) {
+          playAudio(fullAudioUrl, false);
+        }
+      }, 1000);
+      Haptics.notificationAsync(Haptics.NotificationFeedbackType.Success);
 
       // Save to history
       await saveToHistory({


### PR DESCRIPTION
## Summary
- trigger medium and light haptic feedback when starting and stopping recordings
- automatically play back the translated audio and trigger success haptic feedback after translation completes

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68e196e5504c832aa07e5e1a191fa3da